### PR TITLE
make liblzma reference independent of OS

### DIFF
--- a/lzmaffi/_lzmamodule2.py
+++ b/lzmaffi/_lzmamodule2.py
@@ -283,7 +283,7 @@ void _pylzma_stream_init(lzma_stream *strm) {
 uint32_t _pylzma_block_header_size_decode(uint32_t b) {
     return lzma_block_header_size_decode(b); // macro from lzma.h
 }
-""", libraries=[':liblzma.so.5'], ext_package='_lzmaffi_mods', modulename='_compiled_module')
+""", libraries=['lzma'], ext_package='_lzmaffi_mods', modulename='_compiled_module')
 
 def _new_lzma_stream():
     ret = ffi.new('lzma_stream*')


### PR DESCRIPTION
Thank you for the useful package!

For linking on OS X, we need to link to `liblzma.5.dylib` (or similar), as the suffix for shared libraries is different then on Linux and other Unices. Actually, linking with "-llzma" should be sufficient for both, shouldn't it?

With the change in this pull request, I manage to install on OS X 10.9.4, linking to MacPorts' liblzma.
